### PR TITLE
Fix-Build-Failure

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lyx (2.3.6.1-deepin1) unstable; urgency=medium
+
+  * Fix build failure on deepin RISC-V
+
+ -- Gui-Yue <yuemeng.gui@gmail.com>  Tue, 22 Nov 2022 14:32:09 +0000
+
 lyx (2.3.6-1) unstable; urgency=medium
 
   * New upstream version 2.3.6

--- a/debian/patches/fix-riscv-build-failure.patch
+++ b/debian/patches/fix-riscv-build-failure.patch
@@ -1,0 +1,24 @@
+Description:Include missing lib to avoid build failure on 
+deepin-riscv.
+Author:Gui-Yue <yuemeng.gui@gmail.com>
+--- a/src/lyxfind.cpp
++++ b/src/lyxfind.cpp
+@@ -13,6 +13,7 @@
+  */
+ 
+ #include <config.h>
++#include <iterator>
+ 
+ #include "lyxfind.h"
+ 
+--- a/src/insets/InsetListings.cpp
++++ b/src/insets/InsetListings.cpp
+@@ -10,7 +10,7 @@
+  */
+ 
+ #include <config.h>
+-
++#include <cstring>
+ #include "InsetListings.h"
+ 
+ #include "Buffer.h"

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,4 @@
 0004-Use-python3-internally-in-the-C-code-as-well.patch
 0007-Fix-path-to-perl.patch
 0006-Store-correctly-the-window-position-with-Wayland.patch
+fix-riscv-build-failure.patch


### PR DESCRIPTION
Include "cstring" and "iterator" for cpp files in need to avoid build failure.